### PR TITLE
Additional detailed event telemetry converter

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog.Events;
+
+namespace Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters
+{
+    public class EventDetailTelemetryConverter : EventTelemetryConverter
+    {
+        public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent, ISupportProperties telemetryProperties, IFormatProvider formatProvider)
+        {
+            ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
+                includeLogLevel: true,
+                includeRenderedMessage: true,
+                includeMessageTemplate: true);
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
@@ -5,7 +5,7 @@ using Serilog.Events;
 namespace Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters
 {
     /// <summary>
-    /// Similar to Events, however it allowes loggin LogLevel and Template
+    /// Similar to Events, however it allowes logging LogLevel and Template
     /// </summary>
     public class EventDetailTelemetryConverter : EventTelemetryConverter
     {

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
@@ -4,6 +4,9 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters
 {
+    /// <summary>
+    /// Similar to Events, however it allowes loggin LogLevel and Template
+    /// </summary>
     public class EventDetailTelemetryConverter : EventTelemetryConverter
     {
         public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent, ISupportProperties telemetryProperties, IFormatProvider formatProvider)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventDetailTelemetryConverter.cs
@@ -5,7 +5,7 @@ using Serilog.Events;
 namespace Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters
 {
     /// <summary>
-    /// Similar to Events, however it allowes logging LogLevel and Template
+    /// Similar to Events, however it allows logging LogLevel and Template
     /// </summary>
     public class EventDetailTelemetryConverter : EventTelemetryConverter
     {

--- a/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
@@ -22,6 +22,9 @@ namespace Serilog
 
         public static ITelemetryConverter Events => new EventTelemetryConverter();
 
+        /// <summary>
+        /// Similar to Events, however it allowes loggin LogLevel and Template
+        /// </summary>
         public static ITelemetryConverter EventsDetailed => new EventDetailTelemetryConverter();
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
@@ -23,7 +23,7 @@ namespace Serilog
         public static ITelemetryConverter Events => new EventTelemetryConverter();
 
         /// <summary>
-        /// Similar to Events, however it allowes loggin LogLevel and Template
+        /// Similar to Events, however it allowes logging LogLevel and Template
         /// </summary>
         public static ITelemetryConverter EventsDetailed => new EventDetailTelemetryConverter();
     }

--- a/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
@@ -23,7 +23,7 @@ namespace Serilog
         public static ITelemetryConverter Events => new EventTelemetryConverter();
 
         /// <summary>
-        /// Similar to Events, however it allowes logging LogLevel and Template
+        /// Similar to Events, however it allows logging LogLevel and Template
         /// </summary>
         public static ITelemetryConverter EventsDetailed => new EventDetailTelemetryConverter();
     }

--- a/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
@@ -21,5 +21,7 @@ namespace Serilog
         public static ITelemetryConverter Traces => new TraceTelemetryConverter();
 
         public static ITelemetryConverter Events => new EventTelemetryConverter();
+
+        public static ITelemetryConverter EventsDetailed => new EventDetailTelemetryConverter();
     }
 }


### PR DESCRIPTION
adding event detail telemetry converter to include log level and template. This new telemetry converter is very important, as some developers needs to include the log level and template.