### PR TITLE
trace: Put LogLevel, MessageTemplate by default

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/src/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -1,5 +1,5 @@
-using Microsoft.ApplicationInsights.Channel;
 using Serilog.Context;
+using Serilog.ExtensionMethods;
 using Xunit;
 
 namespace Serilog.Sinks.ApplicationInsights.Tests
@@ -7,19 +7,27 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
     public class FormattingTests : ApplicationInsightsTest
     {
         [Fact]
-        public void Log_level_is_not_in_trace_custom_property()
+        public void Log_level_is_in_trace_custom_property()
         {
             Logger.Information("test");
 
-            Assert.False(LastSubmittedTraceTelemetry.Properties.ContainsKey("LogLevel"));
+            Assert.True(LastSubmittedTraceTelemetry.Properties.ContainsKey(LogEventExtensions.TelemetryPropertiesLogLevel));
         }
 
         [Fact]
-        public void Message_template_is_not_in_trace_custom_property()
+        public void Rendered_message_is_not_in_trace_custom_property()
         {
             Logger.Information("test");
 
-            Assert.False(LastSubmittedTraceTelemetry.Properties.ContainsKey("MessageTemplate"));
+            Assert.False(LastSubmittedTraceTelemetry.Properties.ContainsKey(LogEventExtensions.TelemetryPropertiesRenderedMessage));
+        }
+
+        [Fact]
+        public void Message_template_is_in_trace_custom_property()
+        {
+            Logger.Information("test");
+
+            Assert.True(LastSubmittedTraceTelemetry.Properties.ContainsKey(LogEventExtensions.TelemetryPropertiesMessageTemplate));
         }
 
         [Fact]

--- a/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/ExtensionMethods/LogEventExtensions.cs
@@ -179,9 +179,9 @@ namespace Serilog.ExtensionMethods
         public static TraceTelemetry ToDefaultTraceTelemetry(
             this LogEvent logEvent,
             IFormatProvider formatProvider,
-            bool includeLogLevelAsProperty = false,
+            bool includeLogLevelAsProperty = true,
             bool includeRenderedMessageAsProperty = false,
-            bool includeMessageTemplateAsProperty = false)
+            bool includeMessageTemplateAsProperty = true)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
 


### PR DESCRIPTION
`includeLogLevelAsProperty`, `includeMessageTemplateAsProperty` bools for trace were `true` before and were changed (accidentally, perhaps) to `false` in commit `1eb4fb4 ("Trace does not include LogLevel and MessageTemplate by default (#36)", 2019-01-28)`. So revert those to be `true` so that highest version in 2.x has the intended behavior which is same as v3.x.