### PR TITLE
Update TelemetryConfiguration.Active on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The simplest way to configure Serilog to send data to a ApplicationInsights dash
 ```csharp
 var log = new LoggerConfiguration()
     .WriteTo
-	.ApplicationInsights(TelemetryConfiguration.Active, TelemetryConverter.Traces)
+	.ApplicationInsights(TelemetryConfiguration.CreateDefault(), TelemetryConverter.Traces)
     .CreateLogger();
 ```
 
@@ -24,7 +24,7 @@ var log = new LoggerConfiguration()
 ```csharp
 var log = new LoggerConfiguration()
     .WriteTo
-	.ApplicationInsights(TelemetryConfiguration.Active, TelemetryConverter.Events)
+	.ApplicationInsights(TelemetryConfiguration.CreateDefault(), TelemetryConverter.Events)
     .CreateLogger();
 ```
 


### PR DESCRIPTION
TelemetryConfiguration.Active is now obsolete, this commits updates the docs to help new users.