### PR TITLE
Fix string quoting/escaping in message and properties

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
     /// </summary>
     public abstract class TelemetryConverterBase : ITelemetryConverter
     {
-        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:lj}");
+        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:l}");
 
         /// The <see cref="LogEvent.Level"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
         /// </summary>
@@ -115,6 +115,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
                 var sw = new StringWriter();
                 MessageTemplateTextFormatter.Format(logEvent, sw);
                 telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, sw.ToString());
+                // telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, logEvent.RenderMessage(formatProvider));
             }
 
             if (includeMessageTemplate)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
+using Serilog.Formatting.Display;
 using Serilog.Sinks.ApplicationInsights.Formatters;
 
 namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
@@ -13,6 +15,8 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
     /// </summary>
     public abstract class TelemetryConverterBase : ITelemetryConverter
     {
+        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:lj}");
+
         /// The <see cref="LogEvent.Level"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
         /// </summary>
         public const string TelemetryPropertiesLogLevel = "LogLevel";
@@ -108,7 +112,9 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
 
             if (includeRenderedMessage)
             {
-                telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, logEvent.RenderMessage(formatProvider));
+                var sw = new StringWriter();
+                MessageTemplateTextFormatter.Format(logEvent, sw);
+                telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, sw.ToString());
             }
 
             if (includeMessageTemplate)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -115,7 +115,6 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
                 var sw = new StringWriter();
                 MessageTemplateTextFormatter.Format(logEvent, sw);
                 telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, sw.ToString());
-                // telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, logEvent.RenderMessage(formatProvider));
             }
 
             if (includeMessageTemplate)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -10,7 +10,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
 {
     public class TraceTelemetryConverter : TelemetryConverterBase
     {
-        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:lj}");
+        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:l}");
 
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
@@ -23,6 +23,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
                 MessageTemplateTextFormatter.Format(logEvent, sw);
 
                 var telemetry = new TraceTelemetry(sw.ToString())
+                // var telemetry = new TraceTelemetry(logEvent.RenderMessage(formatProvider))
                 {
                     Timestamp = logEvent.Timestamp,
                     SeverityLevel = ToSeverityLevel(logEvent.Level)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -21,9 +21,8 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
             {
                 var sw = new StringWriter();
                 MessageTemplateTextFormatter.Format(logEvent, sw);
-                var renderedMessage = sw.ToString();
 
-                var telemetry = new TraceTelemetry(renderedMessage)
+                var telemetry = new TraceTelemetry(sw.ToString())
                 {
                     Timestamp = logEvent.Timestamp,
                     SeverityLevel = ToSeverityLevel(logEvent.Level)

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
+using Serilog.Formatting.Display;
 
 namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
 {
     public class TraceTelemetryConverter : TelemetryConverterBase
     {
+        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:lj}");
+
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
             if (logEvent == null)
@@ -15,7 +19,9 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
 
             if (logEvent.Exception == null)
             {
-                var renderedMessage = logEvent.RenderMessage(formatProvider);
+                var sw = new StringWriter();
+                MessageTemplateTextFormatter.Format(logEvent, sw);
+                var renderedMessage = sw.ToString();
 
                 var telemetry = new TraceTelemetry(renderedMessage)
                 {

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -23,7 +23,6 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
                 MessageTemplateTextFormatter.Format(logEvent, sw);
 
                 var telemetry = new TraceTelemetry(sw.ToString())
-                // var telemetry = new TraceTelemetry(logEvent.RenderMessage(formatProvider))
                 {
                     Timestamp = logEvent.Timestamp,
                     SeverityLevel = ToSeverityLevel(logEvent.Level)

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
@@ -33,5 +33,10 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
                 .OfType<TraceTelemetry>()
                 .LastOrDefault();
 
+        protected EventTelemetry LastSubmittedEventTelemetry =>
+            _channel.SubmittedTelemetry
+                .OfType<EventTelemetry>()
+                .LastOrDefault();
+
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -22,12 +22,5 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");
             Assert.Equal("Data: This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
         }
-
-        [Fact]
-        public void MessagePropertyQuotesAreNotEscaped()
-        {
-            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["MyData"]);
-        }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -15,5 +15,23 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
             Logger.Information("Hello, {Name}!", "world");
             Assert.Equal("Hello, world!", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
         }
+
+        [Fact]
+        public void MessageQuotesAreNotEscaped()
+        {
+            var value = "This string is \"quoted\"";
+            Logger.Information("Data: {MyData}", value);
+
+            Assert.Equal($"Data: {value}", LastSubmittedTraceTelemetry.Message);
+        }
+
+        [Fact]
+        public void MessagePropertyQuotesAreNotEscaped()
+        {
+            var value = "This string is \"quoted\"";
+            Logger.Information("Data: {MyData}", value);
+
+            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["MyData"]);
+        }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -20,14 +20,14 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         public void MessageQuotesAreNotEscaped()
         {
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
+            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
         }
 
         [Fact]
         public void MessagePropertyQuotesAreNotEscaped()
         {
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("This string is \"quoted\"", LastSubmittedTraceTelemetry.Properties["MyData"]);
+            Assert.Equal("This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["MyData"]);
         }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -19,19 +19,15 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         [Fact]
         public void MessageQuotesAreNotEscaped()
         {
-            var value = "This string is \"quoted\"";
-            Logger.Information("Data: {MyData}", value);
-
-            Assert.Equal($"Data: {value}", LastSubmittedTraceTelemetry.Message);
+            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
         }
 
         [Fact]
         public void MessagePropertyQuotesAreNotEscaped()
         {
-            var value = "This string is \"quoted\"";
-            Logger.Information("Data: {MyData}", value);
-
-            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["MyData"]);
+            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+            Assert.Equal("This string is \"quoted\"", LastSubmittedTraceTelemetry.Properties["MyData"]);
         }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -17,6 +17,13 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         }
 
         [Fact]
+        public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
+        {
+            Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
+            Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+        }
+
+        [Fact]
         public void MessageQuotesAreNotEscaped()
         {
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -1,0 +1,19 @@
+﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using Xunit;
+
+namespace Serilog.Sinks.ApplicationInsights.Tests
+{
+    public class EventTelemetryConverterTest : ApplicationInsightsTest
+    {
+        public EventTelemetryConverterTest() : base(new EventTelemetryConverter())
+        {
+        }
+
+        [Fact]
+        public void MessagesAreFormattedWithoutQuotedStrings()
+        {
+            Logger.Information("Hello, {Name}!", "world");
+            Assert.Equal("Hello, world!", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+        }
+    }
+}

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -68,14 +68,5 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
                 Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Component.Version);
             }
         }
-
-        [Fact]
-        public void Message_property_quotes_are_not_escaped()
-        {
-            var value = "This string is \"quoted\"";
-            Logger.Information("Data: {MyData}", value);
-
-            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["MyData"]);
-        }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -70,15 +70,6 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         }
 
         [Fact]
-        public void Message_quotes_are_not_escaped()
-        {
-            var value = "This string is \"quoted\"";
-            Logger.Information("Data: {MyData}", value);
-
-            Assert.Equal($"Data: {value}", LastSubmittedTraceTelemetry.Message);
-        }
-
-        [Fact]
         public void Message_property_quotes_are_not_escaped()
         {
             var value = "This string is \"quoted\"";

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -73,18 +73,18 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         public void Message_quotes_are_not_escaped()
         {
             var value = "This string is \"quoted\"";
-            Logger.Information("Data:\n{JsonData}", value);
+            Logger.Information("Data: {MyData}", value);
 
-            Assert.Equal($"Data: \"{value}\"", LastSubmittedTraceTelemetry.Message);
+            Assert.Equal($"Data: {value}", LastSubmittedTraceTelemetry.Message);
         }
 
         [Fact]
         public void Message_property_quotes_are_not_escaped()
         {
             var value = "This string is \"quoted\"";
-            Logger.Information("Data:\n{JsonData}", value);
+            Logger.Information("Data: {MyData}", value);
 
-            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["JsonData"]);
+            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["MyData"]);
         }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -68,5 +68,23 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
                 Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Component.Version);
             }
         }
+
+        [Fact]
+        public void Message_quotes_are_not_escaped()
+        {
+            var value = "This string is \"quoted\"";
+            Logger.Information("Data:\n{JsonData}", value);
+
+            Assert.Equal($"Data: \"{value}\"", LastSubmittedTraceTelemetry.Message);
+        }
+
+        [Fact]
+        public void Message_property_quotes_are_not_escaped()
+        {
+            var value = "This string is \"quoted\"";
+            Logger.Information("Data:\n{JsonData}", value);
+
+            Assert.Equal($"{value}", LastSubmittedTraceTelemetry.Properties["JsonData"]);
+        }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -17,6 +17,13 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
         }
 
         [Fact]
+        public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
+        {
+            Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
+            Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedTraceTelemetry.Message);
+        }
+
+        [Fact]
         public void MessageQuotesAreNotEscaped()
         {
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -22,12 +22,5 @@ namespace Serilog.Sinks.ApplicationInsights.Tests
             Logger.Information("Data: {MyData}", "This string is \"quoted\"");
             Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
         }
-
-        [Fact]
-        public void MessagePropertyQuotesAreNotEscaped()
-        {
-            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("This string is \"quoted\"", LastSubmittedTraceTelemetry.Properties["MyData"]);
-        }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -1,0 +1,33 @@
+﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using Xunit;
+
+namespace Serilog.Sinks.ApplicationInsights.Tests
+{
+    public class TraceTelemetryConverterTest : ApplicationInsightsTest
+    {
+        public TraceTelemetryConverterTest() : base(new TraceTelemetryConverter())
+        {
+        }
+
+        [Fact]
+        public void MessagesAreFormattedWithoutQuotedStrings()
+        {
+            Logger.Information("Hello, {Name}!", "world");
+            Assert.Equal("Hello, world!", LastSubmittedTraceTelemetry.Message);
+        }
+
+        [Fact]
+        public void MessageQuotesAreNotEscaped()
+        {
+            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
+        }
+
+        [Fact]
+        public void MessagePropertyQuotesAreNotEscaped()
+        {
+            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+            Assert.Equal("This string is \"quoted\"", LastSubmittedTraceTelemetry.Properties["MyData"]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #137
Fixes #117

Need help, currently not working. The proposed solution from https://github.com/serilog-contrib/serilog-sinks-applicationinsights/issues/137#issuecomment-1115434026 wasn't right, it seems. Or I misunderstood it. When I run the new tests, then the `includeRenderedMessage` in that method is `false`, so the modified code isn't called.

For consideration:
* The most important part for me is the property data itself, though it would be nice to have the option of not quoting message strings, too.
* Should this be configurable? If so, I need guidance.