### PR TITLE
Reformat code, update to C# 10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,3 @@
 2.0.0
- * Moved the Application Insights sink from its [original location](https://github.com/serilog/serilog)
+
+* Moved the Application Insights sink from its [original location](https://github.com/serilog/serilog)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,0 @@
-2.0.0
-
-* Moved the Application Insights sink from its [original location](https://github.com/serilog/serilog)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Serilog.Sinks.ApplicationInsights [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Sinks.ApplicationInsights.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.ApplicationInsights/)
 
-A sink for Serilog that writes events to Microsoft Application Insights. This sink comes with several defaults that send Serilog `LogEvent` messages to Application Insights as either `EventTelemetry` or `TraceTelemetry`.
+A sink for Serilog that writes events to Microsoft Application Insights. This sink comes with several defaults that send
+Serilog `LogEvent` messages to Application Insights as either `EventTelemetry` or `TraceTelemetry`.
 
 ## Configuring
 
-The simplest way to configure Serilog to send data to a Application Insights dashboard via instrumentation key is to use current active *telemetry configuration* which is already initialised in most application types like ASP.NET Core, Azure Functions etc.:
+The simplest way to configure Serilog to send data to a Application Insights dashboard via instrumentation key is to use
+current active *telemetry configuration* which is already initialised in most application types like ASP.NET Core, Azure
+Functions etc.:
 
 ```csharp
 var log = new LoggerConfiguration()
@@ -12,9 +15,7 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-
 .. or as `EventTelemetry`:
-
 
 ```csharp
 var log = new LoggerConfiguration()
@@ -22,15 +23,26 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-> You can also pass an *instrumentation key* and this sink will create a new `TelemetryConfiguration` based on it, however it's actively discouraged compared to using already initialised telemetry configuration, as your telemetry won't be properly correlated.
+> You can also pass an *instrumentation key* and this sink will create a new `TelemetryConfiguration` based on it,
+> however it's actively discouraged compared to using already initialised telemetry configuration, as your telemetry
+> won't
+> be properly correlated.
 
-**Note:** Whether you choose `Events` or `Traces`, if the LogEvent contains any exceptions it will always be sent as `ExceptionTelemetry`.
+**Note:** Whether you choose `Events` or `Traces`, if the LogEvent contains any exceptions it will always be sent
+as `ExceptionTelemetry`.
 
 ### `TelemetryConfiguration.Active` is deprecated in the App Insights SDK for .NET Core, what do I do?
 
-The singleton [`TelemetryConfiguration.Active` has been deprecated in the Application Insights SDK on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152).
+The
+singleton [`TelemetryConfiguration.Active` has been deprecated in the Application Insights SDK on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152)
+.
 
-Therefore, now we need to pass in the `TelemetryConfiguration` instance that was added either by `services.AddApplicationInsightsTelemetryWorkerService()` (if you're developing a [non-http applciation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/worker-service)) or `services.AddApplicationInsightsTelemetry()` (if you're developing an [ASP.Net Core applciation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core)) during Startup in `ConfigureServices`.
+Therefore, now we need to pass in the `TelemetryConfiguration` instance that was added either
+by `services.AddApplicationInsightsTelemetryWorkerService()` (if you're developing
+a [non-http applciation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/worker-service))
+or `services.AddApplicationInsightsTelemetry()` (if you're developing
+an [ASP.Net Core applciation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core)) during Startup
+in `ConfigureServices`.
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
@@ -40,9 +52,12 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-However, you probably want to setup your Logger as close to the entry point of your application as possible, so that any startup errors can be caught and properly logged. The problem is that now we're in a chicken-and-egg situation: we want to setup the logger early, but we need the `TelemetryConfiguration` which still haven't been added to our DI container.
+However, you probably want to setup your Logger as close to the entry point of your application as possible, so that any
+startup errors can be caught and properly logged. The problem is that now we're in a chicken-and-egg situation: we want
+to setup the logger early, but we need the `TelemetryConfiguration` which still haven't been added to our DI container.
 
-Luckily [from version 4.0.x of the `Serilog.Extensions.Hosting` we have the possibility to configure a bootstrap logger](https://nblumhardt.com/2020/10/bootstrap-logger/) to capture early errors, and then change it using DI dependant services once they are configured.
+Luckily [from version 4.0.x of the `Serilog.Extensions.Hosting` we have the possibility to configure a bootstrap logger](https://nblumhardt.com/2020/10/bootstrap-logger/)
+to capture early errors, and then change it using DI dependant services once they are configured.
 
 ```csharp
 // dotnet add package serilog.extensions.hosting -v 4.0.0-*
@@ -81,7 +96,9 @@ public static class Program
 
 ### Configuring with `ReadFrom.Configuration()`
 
-The following configuration shows how to create an ApplicationInsights sink with [ReadFrom.Configuration(configuration)](https://github.com/serilog/serilog-settings-configuration) - the telemetry converter has to be specified with the full type name and the assembly name: 
+The following configuration shows how to create an ApplicationInsights sink
+with [ReadFrom.Configuration(configuration)](https://github.com/serilog/serilog-settings-configuration) - the telemetry
+converter has to be specified with the full type name and the assembly name:
 
 ```json
 {
@@ -120,6 +137,7 @@ The following configuration shows how to create an ApplicationInsights sink with
 ## What do we submit?
 
 By default, trace telemetry submits:
+
 - **rendered message** in trace's standard *message* property.
 - **severity** in trace's standard *severityLevel* property.
 - **timestamp** in trace's standard *timestamp* property.
@@ -127,18 +145,21 @@ By default, trace telemetry submits:
 - **custom log properties** as *customDimensions*.
 
 Event telemetry submits:
+
 - **message template** as *event name*.
 - **renderedMessage** in *customDimensions*.
 - **timestamp** in event's standard *timestamp* property.
 - **custom log properties** as *customDimensions*.
 
 Exception telemetry submits:
+
 - **exception** as standard AI exception.
 - **severity** in trace's standard *severityLevel* property.
 - **timestamp** in trace's standard *timestamp* property.
 - **custom log properties** as *customDimensions*.
 
-> Note that **log context** properties are also included in *customDimensions* when Serilog is configured with `.Enrich.FromLogContext()`.
+> Note that **log context** properties are also included in *customDimensions* when Serilog is configured
+> with `.Enrich.FromLogContext()`.
 
 ## How custom properties are logged?
 
@@ -184,8 +205,10 @@ private class DottedOutTraceTelemetryConverter : TraceTelemetryConverter
 
 ## Customizing
 
-Additionally, you can also customize *whether* to send the LogEvents at all, if so *which type(s)* of Telemetry to send and also *what to send* (all or no LogEvent properties at all) by passing your own `ITelemetryConverter` instead of `TelemetryConverter.Traces` or `TelemetryConverter.Events` by either implementing your own `ITelemetryConverter` or deriving from `TraceTelemetryConverter` or `EventTelemetryConverter` and overriding specific bits.
-
+Additionally, you can also customize *whether* to send the LogEvents at all, if so *which type(s)* of Telemetry to send
+and also *what to send* (all or no LogEvent properties at all) by passing your own `ITelemetryConverter` instead
+of `TelemetryConverter.Traces` or `TelemetryConverter.Events` by either implementing your own `ITelemetryConverter` or
+deriving from `TraceTelemetryConverter` or `EventTelemetryConverter` and overriding specific bits.
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
@@ -239,7 +262,8 @@ If you want to skip sending a particular LogEvent, just return `null` from your 
 
 ### Customising included properties
 
-The easiest way to customise included properties is to subclass one of the `ITelemetryConverter` implementations. For instance, let's include `renderedMessage` in event telemetry:
+The easiest way to customise included properties is to subclass one of the `ITelemetryConverter` implementations. For
+instance, let's include `renderedMessage` in event telemetry:
 
 ```csharp
 private class IncludeRenderedMessageConverter : EventTelemetryConverter
@@ -256,10 +280,14 @@ private class IncludeRenderedMessageConverter : EventTelemetryConverter
 ```
 
 ## How, When and Why to Flush Messages Manually
-		
+
 ### Or: Where did my Messages go?
 
-As explained by the [Application Insights documentation](https://azure.microsoft.com/en-us/documentation/articles/app-insights-api-custom-events-metrics/#flushing-data), the default behaviour of the AI client is to buffer messages and send them to AI in batches whenever the client seems fit. However, this may lead to lost messages when your application terminates while there are still unsent messages in said buffer.
+As explained by
+the [Application Insights documentation](https://azure.microsoft.com/en-us/documentation/articles/app-insights-api-custom-events-metrics/#flushing-data)
+, the default behaviour of the AI client is to buffer messages and send them to AI in batches whenever the client seems
+fit. However, this may lead to lost messages when your application terminates while there are still unsent messages in
+said buffer.
 
 You can control when AI shall flush its messages, for example when your application closes:
 
@@ -303,7 +331,8 @@ System.Threading.Thread.Sleep(1000);
 
 ## Including Operation Id
 
-Application Insight's operation id is pushed out if you set `operationId` LogEvent property. If it's present, AI's operation id will be overriden by the value from this property.
+Application Insight's operation id is pushed out if you set `operationId` LogEvent property. If it's present, AI's
+operation id will be overriden by the value from this property.
 
 This can be set like so:
 
@@ -323,13 +352,19 @@ public class OperationIdEnricher : ILogEventEnricher
 
 ## Including Version
 
-Application Insight supports component version and is pushed out if you set `version` log event property. If it's present, AI's operation version will include the value from this property.
+Application Insight supports component version and is pushed out if you set `version` log event property. If it's
+present, AI's operation version will include the value from this property.
 
 ## Using with Azure Functions
 
-Azure functions has out of the box integration with Application Insights, which automatically logs functions execution start, end, and any exception. Please refer to the [original documenation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-monitoring) on how to enable it.
+Azure functions has out of the box integration with Application Insights, which automatically logs functions execution
+start, end, and any exception. Please refer to
+the [original documenation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-monitoring) on how to
+enable it.
 
-This sink can enrich AI messages, preserving *operation_Id* and other context information which is *already provided by functions runtime*. The easiest way to configure Serilog in this case is to use **TelemetryConfiguration.Active** which is already properly configured. You can, for instance, initialise logging in the static constructor:
+This sink can enrich AI messages, preserving *operation_Id* and other context information which is *already provided by
+functions runtime*. The easiest way to configure Serilog in this case is to use **TelemetryConfiguration.Active** which
+is already properly configured. You can, for instance, initialise logging in the static constructor:
 
 ```csharp
 public static class MyFunctions
@@ -348,6 +383,7 @@ public static class MyFunctions
 }
 ```
 
-Copyright &copy; 2021 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html).
+Copyright &copy; 2021 Serilog Contributors - Provided under
+the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html).
 
 See also: [Serilog Documentation](https://github.com/serilog/serilog/wiki)

--- a/serilog-sinks-applicationinsights.sln
+++ b/serilog-sinks-applicationinsights.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{E9D1B5E1
 		README.md = README.md
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		CHANGES.md = CHANGES.md
 		LICENSE = LICENSE
 	EndProjectSection
 EndProject

--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
@@ -21,104 +21,109 @@ using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
-namespace Serilog
+namespace Serilog;
+
+/// <summary>
+///     Adds the WriteTo.ApplicationInsights() extension method to <see cref="LoggerConfiguration" />.
+/// </summary>
+public static class LoggerConfigurationApplicationInsightsExtensions
 {
+    /// <summary>
+    ///     Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights
+    ///     using a custom <see cref="ITelemetry" /> converter / constructor.
+    /// </summary>
+    /// <param name="loggerConfiguration">The logger configuration.</param>
+    /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
+    /// <param name="telemetryConverter">Required telemetry converter.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+    /// <param name="levelSwitch">Logging level switch for this sink</param>
+    /// <returns></returns>
+    public static LoggerConfiguration ApplicationInsights(
+        this LoggerSinkConfiguration loggerConfiguration,
+        TelemetryConfiguration telemetryConfiguration,
+        ITelemetryConverter telemetryConverter,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch levelSwitch = null)
+    {
+#pragma warning disable CS0618
+        var client = new TelemetryClient(telemetryConfiguration ?? TelemetryConfiguration.Active);
+#pragma warning restore CS0618
+
+        return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter),
+            restrictedToMinimumLevel, levelSwitch);
+    }
 
     /// <summary>
-    /// Adds the WriteTo.ApplicationInsights() extension method to <see cref="LoggerConfiguration"/>.
+    ///     Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights
+    ///     using the active <see cref="TelemetryConfiguration" />
     /// </summary>
-    public static class LoggerConfigurationApplicationInsightsExtensions
+    /// <param name="loggerConfiguration">The logger configuration.</param>
+    /// <param name="telemetryConverter">Required telemetry converter.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+    /// <param name="levelSwitch">Logging level switch for this sink</param>
+    /// <returns></returns>
+    public static LoggerConfiguration ApplicationInsights(
+        this LoggerSinkConfiguration loggerConfiguration,
+        ITelemetryConverter telemetryConverter,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch levelSwitch = null)
     {
-        /// <summary>
-        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
-        /// using a custom <see cref="ITelemetry"/> converter / constructor.
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="telemetryConfiguration">Required Application Insights configuration settings.</param>
-        /// <param name="telemetryConverter">Required telemetry converter.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="levelSwitch">Logging level switch for this sink</param>
-        /// <returns></returns>
-        public static LoggerConfiguration ApplicationInsights(
-            this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryConfiguration telemetryConfiguration,
-            ITelemetryConverter telemetryConverter,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            var client = new TelemetryClient(telemetryConfiguration ?? TelemetryConfiguration.Active);
+#pragma warning disable CS0618
+        var client = new TelemetryClient(TelemetryConfiguration.Active);
+#pragma warning restore CS0618
 
-            return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter), restrictedToMinimumLevel, levelSwitch);
-        }
+        return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter),
+            restrictedToMinimumLevel, levelSwitch);
+    }
 
-        /// <summary>
-        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights
-        /// using the active <see cref="TelemetryConfiguration"/>
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="telemetryConverter">Required telemetry converter.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="levelSwitch">Logging level switch for this sink</param>
-        /// <returns></returns>
-        public static LoggerConfiguration ApplicationInsights(
-            this LoggerSinkConfiguration loggerConfiguration,
-            ITelemetryConverter telemetryConverter,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-
-            var client = new TelemetryClient(TelemetryConfiguration.Active);
-
-            return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter), restrictedToMinimumLevel, levelSwitch);
-        }
-
-        /// <summary>
-        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
-        /// using a custom <see cref="ITelemetry"/> converter / constructor.
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="telemetryClient">Required Application Insights telemetry client.</param>
-        /// <param name="telemetryConverter">Required telemetry converter.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="levelSwitch">Logging level switch for this sink</param>
-        /// <returns></returns>
-        public static LoggerConfiguration ApplicationInsights(
-            this LoggerSinkConfiguration loggerConfiguration,
-            TelemetryClient telemetryClient,
-            ITelemetryConverter telemetryConverter,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            return loggerConfiguration.Sink(new ApplicationInsightsSink(telemetryClient, telemetryConverter), restrictedToMinimumLevel, levelSwitch);
-        }
+    /// <summary>
+    ///     Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights
+    ///     using a custom <see cref="ITelemetry" /> converter / constructor.
+    /// </summary>
+    /// <param name="loggerConfiguration">The logger configuration.</param>
+    /// <param name="telemetryClient">Required Application Insights telemetry client.</param>
+    /// <param name="telemetryConverter">Required telemetry converter.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+    /// <param name="levelSwitch">Logging level switch for this sink</param>
+    /// <returns></returns>
+    public static LoggerConfiguration ApplicationInsights(
+        this LoggerSinkConfiguration loggerConfiguration,
+        TelemetryClient telemetryClient,
+        ITelemetryConverter telemetryConverter,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch levelSwitch = null)
+    {
+        return loggerConfiguration.Sink(new ApplicationInsightsSink(telemetryClient, telemetryConverter),
+            restrictedToMinimumLevel, levelSwitch);
+    }
 
 
-        /// <summary>
-        /// Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights 
-        /// using a custom <see cref="ITelemetry"/> converter / constructor. Only use in rare cases when your application doesn't
-        /// have already constructed AI telemetry configuration, which is extremely rare.
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="instrumentationKey">Required Application Insights key.</param>
-        /// <param name="telemetryConverter">Required telemetry converter.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="levelSwitch">Logging level switch for this sink</param>
-        /// <returns></returns>
-        public static LoggerConfiguration ApplicationInsights(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string instrumentationKey,
-            ITelemetryConverter telemetryConverter,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            var client = new TelemetryClient();
+    /// <summary>
+    ///     Adds a Serilog sink that writes <see cref="LogEvent">log events</see> to Microsoft Application Insights
+    ///     using a custom <see cref="ITelemetry" /> converter / constructor. Only use in rare cases when your application
+    ///     doesn't
+    ///     have already constructed AI telemetry configuration, which is extremely rare.
+    /// </summary>
+    /// <param name="loggerConfiguration">The logger configuration.</param>
+    /// <param name="instrumentationKey">Required Application Insights key.</param>
+    /// <param name="telemetryConverter">Required telemetry converter.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+    /// <param name="levelSwitch">Logging level switch for this sink</param>
+    /// <returns></returns>
+    public static LoggerConfiguration ApplicationInsights(
+        this LoggerSinkConfiguration loggerConfiguration,
+        string instrumentationKey,
+        ITelemetryConverter telemetryConverter,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch levelSwitch = null)
+    {
+#pragma warning disable CS0618
+        var client = new TelemetryClient();
+#pragma warning restore CS0618
 
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
-            {
-                client.InstrumentationKey = instrumentationKey;
-            }
+        if (!string.IsNullOrWhiteSpace(instrumentationKey)) client.InstrumentationKey = instrumentationKey;
 
-            return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter), restrictedToMinimumLevel, levelSwitch);
-        }
+        return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter),
+            restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -18,15 +18,17 @@
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Serilog</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="Serilog" Version="2.11.0"/>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0"/>
   </ItemGroup>
 
   <ItemGroup>
-      <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -23,188 +22,175 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
-namespace Serilog.Sinks.ApplicationInsights
+namespace Serilog.Sinks.ApplicationInsights;
+
+/// <summary>
+///     Base class for Microsoft Azure Application Insights based Sinks.
+///     Inspired by their NLog Appender implementation.
+/// </summary>
+public class ApplicationInsightsSink : ILogEventSink, IDisposable
 {
+    readonly IFormatProvider _formatProvider;
+
+    readonly ITelemetryConverter _telemetryConverter;
+    long _isDisposed;
+    long _isDisposing;
+
+    TelemetryClient _telemetryClient;
+
     /// <summary>
-    /// Base class for Microsoft Azure Application Insights based Sinks.
-    /// Inspired by their NLog Appender implementation.
+    ///     Creates a sink that saves logs to the Application Insights account for the given
+    ///     <paramref name="telemetryClient" /> instance.
     /// </summary>
-    public class ApplicationInsightsSink : ILogEventSink, IDisposable
+    /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
+    /// <param name="telemetryConverter">The <see cref="LogEvent" /> to <see cref="ITelemetry" /> converter.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> cannot be null</exception>
+    public ApplicationInsightsSink(
+        TelemetryClient telemetryClient,
+        ITelemetryConverter telemetryConverter,
+        IFormatProvider formatProvider = null)
     {
-        private long _isDisposing = 0;
-        private long _isDisposed = 0;
+        _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        _telemetryConverter = telemetryConverter ?? throw new ArgumentNullException(nameof(telemetryConverter));
 
-        private TelemetryClient _telemetryClient;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is being disposed.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is being disposed; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsDisposing
-        {
-            get => Interlocked.Read(ref _isDisposing) == 1;
-            protected set => Interlocked.Exchange(ref _isDisposing, value ? 1 : 0);
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance has been disposed.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance has been disposed; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsDisposed
-        {
-            get => Interlocked.Read(ref _isDisposed) == 1;
-            protected set => Interlocked.Exchange(ref _isDisposed, value ? 1 : 0);
-        }
-
-        private readonly IFormatProvider _formatProvider;
-
-        private readonly ITelemetryConverter _telemetryConverter;
-
-        /// <summary>
-        /// Creates a sink that saves logs to the Application Insights account for the given <paramref name="telemetryClient" /> instance.
-        /// </summary>
-        /// <param name="telemetryClient">Required Application Insights <paramref name="telemetryClient" />.</param>
-        /// <param name="telemetryConverter">The <see cref="LogEvent"/> to <see cref="ITelemetry"/> converter.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null for default provider.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="telemetryClient" /> cannot be null</exception>
-        public ApplicationInsightsSink(
-            TelemetryClient telemetryClient,
-            ITelemetryConverter telemetryConverter,
-            IFormatProvider formatProvider = null)
-        {
-            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-            _telemetryConverter = telemetryConverter ?? throw new ArgumentNullException(nameof(telemetryConverter));
-
-            _formatProvider = formatProvider;
-        }
-
-        #region AI specifc Helper methods
-
-        /// <summary>
-        /// Hands over the <paramref name="telemetry" /> to the AI telemetry client.
-        /// </summary>
-        /// <param name="telemetry">The telemetry.</param>
-        /// <exception cref="System.ArgumentNullException">telemetry</exception>
-        protected virtual void TrackTelemetry(ITelemetry telemetry)
-        {
-            if (telemetry == null) throw new ArgumentNullException(nameof(telemetry));
-
-            CheckForAndThrowIfDisposed();
-
-            // the .Track() method is save to use (even though documented otherwise)
-            // see https://github.com/Microsoft/ApplicationInsights-dotnet/issues/244
-            _telemetryClient?.Track(telemetry);
-        }
-
-        #endregion AI specifc Helper methods
-
-        #region Implementation of ILogEventSink
-
-        /// <summary>
-        /// Emit the provided log event to the sink.
-        /// </summary>
-        /// <param name="logEvent">The log event to write.</param>
-        /// <exception cref="Exception">A delegate callback throws an exception.</exception>
-        /// <exception cref="TargetInvocationException">A delegate callback throws an exception.</exception>
-        public virtual void Emit(LogEvent logEvent)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            CheckForAndThrowIfDisposed();
-
-            try
-            {
-                IEnumerable<ITelemetry> telemetries = _telemetryConverter.Convert(logEvent, _formatProvider);
-
-                // if 'null' is returned (& we therefore there's nothing to track), the logEvent is basically skipped
-                if (telemetries != null)
-                {
-                    foreach (ITelemetry telemetry in telemetries)
-                    {
-                        if (telemetry != null)
-                        {
-                            TrackTelemetry(telemetry);
-                        }
-                    }
-                }
-            }
-            catch (TargetInvocationException targetInvocationException)
-            {
-                // rethrow original exception (inside the TargetInvocationException) if any
-                if (targetInvocationException.InnerException != null)
-                {
-                    ExceptionDispatchInfo.Capture(targetInvocationException.InnerException).Throw();
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-
-        #endregion
-
-        #region Implementation of IDisposable
-
-        /// <summary>
-        /// Checks whether this instance has been disposed and if so, throws an <see cref="ObjectDisposedException"/>.
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        protected void CheckForAndThrowIfDisposed()
-        {
-            if (IsDisposed)
-            {
-                throw new ObjectDisposedException(this.GetType().Name);
-            }
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <param name="disposeManagedResources"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposeManagedResources)
-        {
-            if (IsDisposing || IsDisposed)
-                return;
-
-            try
-            {
-                IsDisposing = true;
-
-                // we only have managed resources to dispose of
-                if (disposeManagedResources)
-                {
-                    // attempt to free managed resources
-                    try
-                    {
-                        _telemetryClient?.Flush();
-                    }
-                    finally
-                    {
-                        _telemetryClient = null;
-                    }
-                }
-            }
-            finally
-            {
-                IsDisposed = true;
-                IsDisposing = false;
-            }
-        }
-
-        #endregion Implementation of IDisposable
+        _formatProvider = formatProvider;
     }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether this instance is being disposed.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if this instance is being disposed; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsDisposing
+    {
+        get => Interlocked.Read(ref _isDisposing) == 1;
+        protected set => Interlocked.Exchange(ref _isDisposing, value ? 1 : 0);
+    }
+
+    /// <summary>
+    ///     Gets a value indicating whether this instance has been disposed.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if this instance has been disposed; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsDisposed
+    {
+        get => Interlocked.Read(ref _isDisposed) == 1;
+        protected set => Interlocked.Exchange(ref _isDisposed, value ? 1 : 0);
+    }
+
+    #region Implementation of ILogEventSink
+
+    /// <summary>
+    ///     Emit the provided log event to the sink.
+    /// </summary>
+    /// <param name="logEvent">The log event to write.</param>
+    /// <exception cref="Exception">A delegate callback throws an exception.</exception>
+    /// <exception cref="TargetInvocationException">A delegate callback throws an exception.</exception>
+    public virtual void Emit(LogEvent logEvent)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+        CheckForAndThrowIfDisposed();
+
+        try
+        {
+            var telemetries = _telemetryConverter.Convert(logEvent, _formatProvider);
+
+            // if 'null' is returned (& we therefore there's nothing to track), the logEvent is basically skipped
+            if (telemetries != null)
+                foreach (var telemetry in telemetries)
+                    if (telemetry != null)
+                        TrackTelemetry(telemetry);
+        }
+        catch (TargetInvocationException targetInvocationException)
+        {
+            // rethrow original exception (inside the TargetInvocationException) if any
+            if (targetInvocationException.InnerException != null)
+                ExceptionDispatchInfo.Capture(targetInvocationException.InnerException).Throw();
+            else
+                throw;
+        }
+    }
+
+    #endregion
+
+    #region AI specifc Helper methods
+
+    /// <summary>
+    ///     Hands over the <paramref name="telemetry" /> to the AI telemetry client.
+    /// </summary>
+    /// <param name="telemetry">The telemetry.</param>
+    /// <exception cref="System.ArgumentNullException">telemetry</exception>
+    protected virtual void TrackTelemetry(ITelemetry telemetry)
+    {
+        if (telemetry == null) throw new ArgumentNullException(nameof(telemetry));
+
+        CheckForAndThrowIfDisposed();
+
+        // the .Track() method is save to use (even though documented otherwise)
+        // see https://github.com/Microsoft/ApplicationInsights-dotnet/issues/244
+        _telemetryClient?.Track(telemetry);
+    }
+
+    #endregion AI specifc Helper methods
+
+    #region Implementation of IDisposable
+
+    /// <summary>
+    ///     Checks whether this instance has been disposed and if so, throws an <see cref="ObjectDisposedException" />.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException"></exception>
+    protected void CheckForAndThrowIfDisposed()
+    {
+        if (IsDisposed) throw new ObjectDisposedException(GetType().Name);
+    }
+
+    /// <summary>
+    ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(disposeManagedResources: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    ///     Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposeManagedResources">
+    ///     <c>true</c> to release both managed and unmanaged resources; <c>false</c> to
+    ///     release only unmanaged resources.
+    /// </param>
+    protected virtual void Dispose(bool disposeManagedResources)
+    {
+        if (IsDisposing || IsDisposed)
+            return;
+
+        try
+        {
+            IsDisposing = true;
+
+            // we only have managed resources to dispose of
+            if (disposeManagedResources)
+                // attempt to free managed resources
+                try
+                {
+                    _telemetryClient?.Flush();
+                }
+                finally
+                {
+                    _telemetryClient = null;
+                }
+        }
+        finally
+        {
+            IsDisposed = true;
+            IsDisposing = false;
+        }
+    }
+
+    #endregion Implementation of IDisposable
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsDottedValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsDottedValueFormatter.cs
@@ -4,75 +4,81 @@ using System.Globalization;
 using Serilog.Debugging;
 using Serilog.Events;
 
-namespace Serilog.Sinks.ApplicationInsights.Formatters
+namespace Serilog.Sinks.ApplicationInsights.Formatters;
+
+#pragma warning disable CS1591
+
+public class ApplicationInsightsDottedValueFormatter : IValueFormatter
 {
-    public class ApplicationInsightsDottedValueFormatter : IValueFormatter
+    static readonly IDictionary<Type, Action<string, object, IDictionary<string, string>>> LiteralWriters =
+        new Dictionary
+            <Type, Action<string, object, IDictionary<string, string>>> {
+                { typeof(SequenceValue), (k, v, p) => WriteSequenceValue(k, (SequenceValue)v, p) },
+                { typeof(DictionaryValue), (k, v, p) => WriteDictionaryValue(k, (DictionaryValue)v, p) },
+                { typeof(StructureValue), (k, v, p) => WriteStructureValue(k, (StructureValue)v, p) },
+                { typeof(ScalarValue), (k, v, p) => WriteValue(k, ((ScalarValue)v).Value, p) },
+                { typeof(DateTime), (k, v, p) => AppendProperty(p, k, ((DateTime)v).ToString("o")) },
+                { typeof(DateTimeOffset), (k, v, p) => AppendProperty(p, k, ((DateTimeOffset)v).ToString("o")) }, {
+                    typeof(float),
+                    (k, v, p) => AppendProperty(p, k, ((float)v).ToString("R", CultureInfo.InvariantCulture))
+                }, {
+                    typeof(double),
+                    (k, v, p) => AppendProperty(p, k, ((double)v).ToString("R", CultureInfo.InvariantCulture))
+                }
+            };
+
+    public void Format(string propertyName, LogEventPropertyValue propertyValue,
+        IDictionary<string, string> properties)
     {
-        private static readonly IDictionary<Type, Action<string, object, IDictionary<string, string>>> LiteralWriters = new Dictionary
-            <Type, Action<string, object, IDictionary<string, string>>>
-        {
-            {typeof (SequenceValue), (k, v, p) => WriteSequenceValue(k, (SequenceValue) v, p)},
-            {typeof (DictionaryValue), (k, v, p) => WriteDictionaryValue(k, (DictionaryValue) v, p)},
-            {typeof (StructureValue), (k, v, p) => WriteStructureValue(k, (StructureValue) v, p)},
-            {typeof (ScalarValue), (k, v, p) => WriteValue(k,((ScalarValue)v).Value,p)},
-            {typeof (DateTime), (k, v, p) => AppendProperty(p,k,((DateTime)v).ToString("o"))},
-            {typeof (DateTimeOffset), (k, v, p) => AppendProperty(p,k,((DateTimeOffset)v).ToString("o"))},
-            {typeof (float), (k, v, p) => AppendProperty(p,k,((float)v).ToString("R", CultureInfo.InvariantCulture))},
-            {typeof (double), (k, v, p) => AppendProperty(p,k,((double)v).ToString("R", CultureInfo.InvariantCulture))},
-        };
+        WriteValue(propertyName, propertyValue, properties);
+    }
 
-        public void Format(string propertyName, LogEventPropertyValue propertyValue, IDictionary<string, string> properties)
+    static void WriteStructureValue(string key, StructureValue structureValue,
+        IDictionary<string, string> properties)
+    {
+        foreach (var eventProperty in structureValue.Properties)
+            WriteValue(key + "." + eventProperty.Name, eventProperty.Value, properties);
+    }
+
+    static void WriteDictionaryValue(string key, DictionaryValue dictionaryValue,
+        IDictionary<string, string> properties)
+    {
+        foreach (var eventProperty in dictionaryValue.Elements)
+            WriteValue(key + "." + eventProperty.Key.Value, eventProperty.Value, properties);
+    }
+
+    static void WriteSequenceValue(string key, SequenceValue sequenceValue, IDictionary<string, string> properties)
+    {
+        var index = 0;
+        foreach (var eventProperty in sequenceValue.Elements)
         {
-            WriteValue(propertyName, propertyValue, properties);
+            WriteValue(key + "." + index, eventProperty, properties);
+            index++;
         }
 
-        private static void WriteStructureValue(string key, StructureValue structureValue, IDictionary<string, string> properties)
+        AppendProperty(properties, key + ".Count", index.ToString());
+    }
+
+    public static void WriteValue(string key, object value, IDictionary<string, string> properties)
+    {
+        Action<string, object, IDictionary<string, string>> writer;
+        if (value == null || !LiteralWriters.TryGetValue(value.GetType(), out writer))
         {
-            foreach (var eventProperty in structureValue.Properties)
-            {
-                WriteValue(key + "." + eventProperty.Name, eventProperty.Value, properties);
-            }
+            AppendProperty(properties, key, value?.ToString());
+            return;
         }
 
-        private static void WriteDictionaryValue(string key, DictionaryValue dictionaryValue, IDictionary<string, string> properties)
+        writer(key, value, properties);
+    }
+
+    static void AppendProperty(IDictionary<string, string> propDictionary, string key, string value)
+    {
+        if (propDictionary.ContainsKey(key))
         {
-            foreach (var eventProperty in dictionaryValue.Elements)
-            {
-                WriteValue(key + "." + eventProperty.Key.Value, eventProperty.Value, properties);
-            }
+            SelfLog.WriteLine("The key {0} is not unique after simplification. Ignoring new value {1}", key, value);
+            return;
         }
 
-        private static void WriteSequenceValue(string key, SequenceValue sequenceValue, IDictionary<string, string> properties)
-        {
-            int index = 0;
-            foreach (var eventProperty in sequenceValue.Elements)
-            {
-                WriteValue(key + "." + index, eventProperty, properties);
-                index++;
-            }
-            AppendProperty(properties, key + ".Count", index.ToString());
-        }
-
-        public static void WriteValue(string key, object value, IDictionary<string, string> properties)
-        {
-            Action<string, object, IDictionary<string, string>> writer;
-            if (value == null || !LiteralWriters.TryGetValue(value.GetType(), out writer))
-            {
-                AppendProperty(properties, key, value?.ToString());
-                return;
-            }
-
-            writer(key, value, properties);
-        }
-
-        private static void AppendProperty(IDictionary<string, string> propDictionary, string key, string value)
-        {
-            if (propDictionary.ContainsKey(key))
-            {
-                SelfLog.WriteLine("The key {0} is not unique after simplification. Ignoring new value {1}", key, value);
-                return;
-            }
-            propDictionary.Add(key, value);
-        }
+        propDictionary.Add(key, value);
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsJsonValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsJsonValueFormatter.cs
@@ -4,31 +4,34 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 
-namespace Serilog.Sinks.ApplicationInsights.Formatters
+namespace Serilog.Sinks.ApplicationInsights.Formatters;
+
+#pragma warning disable CS1591
+
+public class ApplicationInsightsJsonValueFormatter : IValueFormatter
 {
-    public class ApplicationInsightsJsonValueFormatter : IValueFormatter
+    static readonly char[] TrimChars = { '\"' };
+    readonly JsonValueFormatter _formatter = new();
+
+    public void Format(string propertyName, LogEventPropertyValue propertyValue,
+        IDictionary<string, string> properties)
     {
-        private readonly JsonValueFormatter _formatter = new JsonValueFormatter();
-        private static readonly char[] TrimChars = new[] { '\"' };
-
-        public void Format(string propertyName, LogEventPropertyValue propertyValue, IDictionary<string, string> properties)
+        string value;
+        using (var sw = new StringWriter())
         {
-            string value;
-            using (var sw = new StringWriter())
-            {
-                _formatter.Format(propertyValue, sw);
-                value = sw.ToString();
-            }
-
-            value = value.Trim(TrimChars);
-
-            if (properties.ContainsKey(propertyName))
-            {
-                SelfLog.WriteLine("The key {0} is not unique after simplification. Ignoring new value {1}", propertyName, value);
-                return;
-            }
-
-            properties.Add(propertyName, value);
+            _formatter.Format(propertyValue, sw);
+            value = sw.ToString();
         }
+
+        value = value.Trim(TrimChars);
+
+        if (properties.ContainsKey(propertyName))
+        {
+            SelfLog.WriteLine("The key {0} is not unique after simplification. Ignoring new value {1}",
+                propertyName, value);
+            return;
+        }
+
+        properties.Add(propertyName, value);
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/IValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/IValueFormatter.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using Serilog.Events;
 
-namespace Serilog.Sinks.ApplicationInsights.Formatters
+namespace Serilog.Sinks.ApplicationInsights.Formatters;
+
+#pragma warning disable CS1591
+
+public interface IValueFormatter
 {
-    public interface IValueFormatter
-    {
-        void Format(string propertyName, LogEventPropertyValue propertyValue, IDictionary<string, string> properties);
-    }
+    void Format(string propertyName, LogEventPropertyValue propertyValue, IDictionary<string, string> properties);
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/EventTelemetryConverter.cs
@@ -4,37 +4,39 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
-namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
+namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+
+#pragma warning disable CS1591
+
+public class EventTelemetryConverter : TelemetryConverterBase
 {
-    public class EventTelemetryConverter : TelemetryConverterBase
+    public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
     {
-        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+        if (logEvent.Exception == null)
         {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text) {
+                Timestamp = logEvent.Timestamp
+            };
 
-            if (logEvent.Exception == null)
-            {
-                var telemetry = new EventTelemetry(logEvent.MessageTemplate.Text) {
-                    Timestamp = logEvent.Timestamp
-                };
+            // write logEvent's .Properties to the AI one
+            ForwardPropertiesToTelemetryProperties(logEvent, telemetry, formatProvider);
 
-                // write logEvent's .Properties to the AI one
-                ForwardPropertiesToTelemetryProperties(logEvent, telemetry, formatProvider);
-
-                yield return telemetry;
-            }
-            else
-            {
-                yield return ToExceptionTelemetry(logEvent, formatProvider);
-            }
+            yield return telemetry;
         }
-
-        public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent, ISupportProperties telemetryProperties, IFormatProvider formatProvider)
+        else
         {
-            ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
-                includeLogLevel: false,
-                includeRenderedMessage: true,
-                includeMessageTemplate: false);
+            yield return ToExceptionTelemetry(logEvent, formatProvider);
         }
+    }
+
+    public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
+        ISupportProperties telemetryProperties, IFormatProvider formatProvider)
+    {
+        ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
+            includeLogLevel: false,
+            includeRenderedMessage: true,
+            includeMessageTemplate: false);
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/ITelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/ITelemetryConverter.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using Microsoft.ApplicationInsights.Channel;
 using Serilog.Events;
 
-namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
+namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+
+#pragma warning disable CS1591
+
+public interface ITelemetryConverter
 {
-    public interface ITelemetryConverter
-    {
-        IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider);
-    }
+    IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider);
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -8,163 +8,175 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.ApplicationInsights.Formatters;
 
-namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters
+namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+
+/// <summary>
+///     Base class for telemetry converters
+/// </summary>
+public abstract class TelemetryConverterBase : ITelemetryConverter
 {
     /// <summary>
-    /// Base class for telemetry converters
+    /// The <see cref="LogEvent.Level" />
+    /// is forwarded to the underlying AI Telemetry and its .Properties using this key.
     /// </summary>
-    public abstract class TelemetryConverterBase : ITelemetryConverter
+    public const string TelemetryPropertiesLogLevel = "LogLevel";
+
+    /// <summary>
+    ///     The <see cref="LogEvent.MessageTemplate" /> is forwarded to the underlying AI Telemetry and its .Properties using
+    ///     this key.
+    /// </summary>
+    public const string TelemetryPropertiesMessageTemplate = "MessageTemplate";
+
+    /// <summary>
+    ///     The result of <see cref="LogEvent.RenderMessage(System.IFormatProvider)" /> is forwarded to the underlying AI
+    ///     Telemetry and its .Properties using this key.
+    /// </summary>
+    public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
+
+    /// <summary>
+    ///     Property that is included when in log context, will be pushed out as AI operation ID.
+    /// </summary>
+    public const string OperationIdProperty = "operationId";
+
+    /// <summary>
+    ///     Property that is included when in log context, will be pushed out as AI component version.
+    /// </summary>
+    public const string VersionProperty = "version";
+
+    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:l}");
+
+    /// <summary>
+    ///     Creates an instance of <see cref="TelemetryConverterBase" /> using default value formatter (
+    ///     <see cref="ApplicationInsightsJsonValueFormatter" />).
+    /// </summary>
+    public TelemetryConverterBase()
     {
-        private static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new MessageTemplateTextFormatter("{Message:l}");
+        ValueFormatter = new ApplicationInsightsJsonValueFormatter();
+    }
 
-        /// The <see cref="LogEvent.Level"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesLogLevel = "LogLevel";
+#pragma warning disable CS1591
+    public virtual IValueFormatter ValueFormatter { get; }
+#pragma warning restore CS1591
 
-        /// <summary>
-        /// The <see cref="LogEvent.MessageTemplate"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesMessageTemplate = "MessageTemplate";
+#pragma warning disable CS1591
+    public abstract IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider);
+#pragma warning restore CS1591
 
-        /// <summary>
-        /// The result of <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> is forwarded to the underlying AI Telemetry and its .Properties using this key.
-        /// </summary>
-        public const string TelemetryPropertiesRenderedMessage = "RenderedMessage";
+#pragma warning disable CS1591
+    public virtual ExceptionTelemetry ToExceptionTelemetry(
+#pragma warning restore CS1591
+        LogEvent logEvent,
+        IFormatProvider formatProvider)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+        if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
 
-        /// <summary>
-        /// Property that is included when in log context, will be pushed out as AI operation ID.
-        /// </summary>
-        public const string OperationIdProperty = "operationId";
+        var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception) {
+            SeverityLevel = ToSeverityLevel(logEvent.Level),
+            Timestamp = logEvent.Timestamp
+        };
 
-        /// <summary>
-        /// Property that is included when in log context, will be pushed out as AI component version.
-        /// </summary>
-        public const string VersionProperty = "version";
+        // write logEvent's .Properties to the AI one
+        ForwardPropertiesToTelemetryProperties(logEvent, exceptionTelemetry, formatProvider);
 
-        public virtual IValueFormatter ValueFormatter { get; }
+        return exceptionTelemetry;
+    }
 
-        public abstract IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider);
+#pragma warning disable CS1591
+    public virtual void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
+#pragma warning restore CS1591
+        ISupportProperties telemetryProperties,
+        IFormatProvider formatProvider)
+    {
+        ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
+            includeLogLevel: false,
+            includeRenderedMessage: false,
+            includeMessageTemplate: true);
+    }
 
-        /// <summary>
-        /// Creates an instance of <see cref="TelemetryConverterBase"/> using default value formatter (<see cref="ApplicationInsightsJsonValueFormatter"/>).
-        /// </summary>
-        public TelemetryConverterBase()
+    /// <summary>
+    ///     Forwards all <see cref="LogEvent" /> data to the <paramref name="telemetryProperties" /> including the log level,
+    ///     rendered message, message template and all <paramref name="logEvent" /> properties to the telemetry.
+    /// </summary>
+    /// <param name="logEvent">The log event.</param>
+    /// <param name="telemetryProperties">The telemetry properties.</param>
+    /// <param name="formatProvider">The format provider.</param>
+    /// <param name="includeLogLevel">
+    ///     if set to <c>true</c> the <see cref="LogEvent.Level" /> is added to the
+    ///     <paramref name="telemetryProperties" /> using the <see cref="TelemetryPropertiesLogLevel" /> key.
+    /// </param>
+    /// <param name="includeRenderedMessage">
+    ///     if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)" /> output is added to the
+    ///     <paramref name="telemetryProperties" /> using the <see cref="TelemetryPropertiesRenderedMessage" /> key.
+    /// </param>
+    /// <param name="includeMessageTemplate">
+    ///     if set to <c>true</c> the <see cref="LogEvent.MessageTemplate" /> is added to the
+    ///     <paramref name="telemetryProperties" /> using the <see cref="TelemetryPropertiesMessageTemplate" /> key.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    ///     Thrown if <paramref name="logEvent" /> or
+    ///     <paramref name="telemetryProperties" /> is null.
+    /// </exception>
+    public void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
+        ISupportProperties telemetryProperties,
+        IFormatProvider formatProvider,
+        bool includeLogLevel,
+        bool includeRenderedMessage,
+        bool includeMessageTemplate)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+        if (telemetryProperties == null) throw new ArgumentNullException(nameof(telemetryProperties));
+
+        if (includeLogLevel)
+            telemetryProperties.Properties.Add(TelemetryPropertiesLogLevel, logEvent.Level.ToString());
+
+        if (includeRenderedMessage)
         {
-            ValueFormatter = new ApplicationInsightsJsonValueFormatter();
+            var sw = new StringWriter();
+            MessageTemplateTextFormatter.Format(logEvent, sw);
+            telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, sw.ToString());
         }
 
-        public virtual ExceptionTelemetry ToExceptionTelemetry(
-            LogEvent logEvent,
-            IFormatProvider formatProvider)
+        if (includeMessageTemplate)
+            telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
+
+        if (telemetryProperties is ITelemetry telemetry)
         {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (logEvent.Exception == null) throw new ArgumentException("Must have an Exception", nameof(logEvent));
+            if (logEvent.Properties.TryGetValue(OperationIdProperty, out var operationId))
+                telemetry.Context.Operation.Id = operationId.ToString().Trim('\"');
 
-            var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception) {
-                SeverityLevel = ToSeverityLevel(logEvent.Level),
-                Timestamp = logEvent.Timestamp
-            };
-
-            // write logEvent's .Properties to the AI one
-            ForwardPropertiesToTelemetryProperties(logEvent, exceptionTelemetry, formatProvider);
-
-            return exceptionTelemetry;
+            if (logEvent.Properties.TryGetValue(VersionProperty, out var version)
+                && telemetry.Context?.Component != null)
+                telemetry.Context.Component.Version = version.ToString().Trim('\"');
         }
 
-        public virtual void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
-            ISupportProperties telemetryProperties,
-            IFormatProvider formatProvider)
+        foreach (var property in logEvent.Properties.Where(property =>
+                     property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
+            ValueFormatter.Format(property.Key, property.Value, telemetryProperties.Properties);
+    }
+
+    /// <summary>
+    ///     To the severity level.
+    /// </summary>
+    /// <param name="logEventLevel">The log event level.</param>
+    /// <returns></returns>
+    public SeverityLevel? ToSeverityLevel(LogEventLevel logEventLevel)
+    {
+        switch (logEventLevel)
         {
-            ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
-                includeLogLevel: false,
-                includeRenderedMessage: false,
-                includeMessageTemplate: true);
+            case LogEventLevel.Verbose:
+            case LogEventLevel.Debug:
+                return SeverityLevel.Verbose;
+            case LogEventLevel.Information:
+                return SeverityLevel.Information;
+            case LogEventLevel.Warning:
+                return SeverityLevel.Warning;
+            case LogEventLevel.Error:
+                return SeverityLevel.Error;
+            case LogEventLevel.Fatal:
+                return SeverityLevel.Critical;
         }
 
-        /// <summary>
-        /// Forwards all <see cref="LogEvent" /> data to the <paramref name="telemetryProperties" /> including the log level,
-        /// rendered message, message template and all <paramref name="logEvent" /> properties to the telemetry.
-        /// </summary>
-        /// <param name="logEvent">The log event.</param>
-        /// <param name="telemetryProperties">The telemetry properties.</param>
-        /// <param name="formatProvider">The format provider.</param>
-        /// <param name="includeLogLevel">if set to <c>true</c> the <see cref="LogEvent.Level"/> is added to the
-        /// <paramref name="telemetryProperties"/> using the <see cref="TelemetryPropertiesLogLevel"/> key.</param>
-        /// <param name="includeRenderedMessage">if set to <c>true</c> the <see cref="LogEvent.RenderMessage(System.IFormatProvider)"/> output is added to the
-        /// <paramref name="telemetryProperties"/> using the <see cref="TelemetryPropertiesRenderedMessage"/> key.</param>
-        /// <param name="includeMessageTemplate">if set to <c>true</c> the <see cref="LogEvent.MessageTemplate"/> is added to the
-        /// <paramref name="telemetryProperties"/> using the <see cref="TelemetryPropertiesMessageTemplate"/> key.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="logEvent" /> or <paramref name="telemetryProperties" /> is null.</exception>
-        public void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
-            ISupportProperties telemetryProperties,
-            IFormatProvider formatProvider,
-            bool includeLogLevel,
-            bool includeRenderedMessage,
-            bool includeMessageTemplate)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (telemetryProperties == null) throw new ArgumentNullException(nameof(telemetryProperties));
-
-            if (includeLogLevel)
-            {
-                telemetryProperties.Properties.Add(TelemetryPropertiesLogLevel, logEvent.Level.ToString());
-            }
-
-            if (includeRenderedMessage)
-            {
-                var sw = new StringWriter();
-                MessageTemplateTextFormatter.Format(logEvent, sw);
-                telemetryProperties.Properties.Add(TelemetryPropertiesRenderedMessage, sw.ToString());
-            }
-
-            if (includeMessageTemplate)
-            {
-                telemetryProperties.Properties.Add(TelemetryPropertiesMessageTemplate, logEvent.MessageTemplate.Text);
-            }
-
-            if (telemetryProperties is ITelemetry telemetry)
-            {
-                if (logEvent.Properties.TryGetValue(OperationIdProperty, out LogEventPropertyValue operationId))
-                {
-                    telemetry.Context.Operation.Id = operationId.ToString().Trim('\"');
-                }
-
-                if (logEvent.Properties.TryGetValue(VersionProperty, out LogEventPropertyValue version)
-                    && telemetry.Context?.Component != null)
-                {
-                    telemetry.Context.Component.Version = version.ToString().Trim('\"');
-                }
-            }
-
-            foreach (KeyValuePair<string, LogEventPropertyValue> property in logEvent.Properties.Where(property => property.Value != null && !telemetryProperties.Properties.ContainsKey(property.Key)))
-            {
-                ValueFormatter.Format(property.Key, property.Value, telemetryProperties.Properties);
-            }
-        }
-
-        /// <summary>
-        /// To the severity level.
-        /// </summary>
-        /// <param name="logEventLevel">The log event level.</param>
-        /// <returns></returns>
-        public SeverityLevel? ToSeverityLevel(LogEventLevel logEventLevel)
-        {
-            switch (logEventLevel)
-            {
-                case LogEventLevel.Verbose:
-                case LogEventLevel.Debug:
-                    return SeverityLevel.Verbose;
-                case LogEventLevel.Information:
-                    return SeverityLevel.Information;
-                case LogEventLevel.Warning:
-                    return SeverityLevel.Warning;
-                case LogEventLevel.Error:
-                    return SeverityLevel.Error;
-                case LogEventLevel.Fatal:
-                    return SeverityLevel.Critical;
-            }
-
-            return null;
-        }
+        return null;
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/TelemetryConverter.cs
@@ -14,12 +14,13 @@
 
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
-namespace Serilog
-{
-    public static class TelemetryConverter
-    {
-        public static ITelemetryConverter Traces => new TraceTelemetryConverter();
+namespace Serilog;
 
-        public static ITelemetryConverter Events => new EventTelemetryConverter();
-    }
+#pragma warning disable CS1591
+
+public static class TelemetryConverter
+{
+    public static ITelemetryConverter Traces => new TraceTelemetryConverter();
+
+    public static ITelemetryConverter Events => new EventTelemetryConverter();
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/ApplicationInsightsTest.cs
@@ -1,42 +1,40 @@
-﻿using Microsoft.ApplicationInsights.Channel;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using System.Collections.Generic;
-using System.Linq;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public abstract class ApplicationInsightsTest
 {
-    public abstract class ApplicationInsightsTest
+    readonly UnitTestTelemetryChannel _channel;
+
+    protected ApplicationInsightsTest(ITelemetryConverter converter = null)
     {
-        private readonly UnitTestTelemetryChannel _channel;
+        var tc = new TelemetryConfiguration("", _channel = new UnitTestTelemetryChannel());
 
-        protected ApplicationInsightsTest(ITelemetryConverter converter = null)
-        {
-            var tc = new TelemetryConfiguration("", _channel = new UnitTestTelemetryChannel());
-
-            Logger = new LoggerConfiguration()
-                .WriteTo.ApplicationInsights(tc, converter ?? TelemetryConverter.Traces)
-                .MinimumLevel.Debug()
-                .Enrich.FromLogContext()
-                .CreateLogger();
-        }
-
-        protected ILogger Logger { get; private set; }
-
-        protected List<ITelemetry> SubmittedTelemetry => _channel.SubmittedTelemetry;
-
-        protected ITelemetry LastSubmittedTelemetry => _channel.SubmittedTelemetry.LastOrDefault();
-
-        protected TraceTelemetry LastSubmittedTraceTelemetry => 
-            _channel.SubmittedTelemetry
-                .OfType<TraceTelemetry>()
-                .LastOrDefault();
-
-        protected EventTelemetry LastSubmittedEventTelemetry =>
-            _channel.SubmittedTelemetry
-                .OfType<EventTelemetry>()
-                .LastOrDefault();
-
+        Logger = new LoggerConfiguration()
+            .WriteTo.ApplicationInsights(tc, converter ?? TelemetryConverter.Traces)
+            .MinimumLevel.Debug()
+            .Enrich.FromLogContext()
+            .CreateLogger();
     }
+
+    protected ILogger Logger { get; }
+
+    protected List<ITelemetry> SubmittedTelemetry => _channel.SubmittedTelemetry;
+
+    protected ITelemetry LastSubmittedTelemetry => _channel.SubmittedTelemetry.LastOrDefault();
+
+    protected TraceTelemetry LastSubmittedTraceTelemetry =>
+        _channel.SubmittedTelemetry
+            .OfType<TraceTelemetry>()
+            .LastOrDefault();
+
+    protected EventTelemetry LastSubmittedEventTelemetry =>
+        _channel.SubmittedTelemetry
+            .OfType<EventTelemetry>()
+            .LastOrDefault();
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/CustomTelemetryConversionTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/CustomTelemetryConversionTest.cs
@@ -1,67 +1,57 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Serilog.Events;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class CustomTelemetryConversionTest : ApplicationInsightsTest
 {
-    public class CustomTelemetryConversionTest : ApplicationInsightsTest
+    public CustomTelemetryConversionTest() : base(new CustomConverter())
     {
-        public CustomTelemetryConversionTest() : base(new CustomConverter())
+    }
+
+    [Fact]
+    public void LogCustom()
+    {
+        Logger.Information("test");
+
+        Assert.Equal("test", LastSubmittedTraceTelemetry.Message);
+    }
+
+    class CustomConverter : TraceTelemetryConverter
+    {
+        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
-
-        }
-
-        [Fact]
-        public void LogCustom()
-        {
-            Logger.Information("test");
-
-            Assert.Equal("test", LastSubmittedTraceTelemetry.Message);
-        }
-
-        private class CustomConverter : TraceTelemetryConverter
-        {
-            public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+            // first create a default TraceTelemetry using the sink's default logic
+            // .. but without the log level, and (rendered) message (template) included in the Properties
+            foreach (var telemetry in base.Convert(logEvent, formatProvider))
             {
-                // first create a default TraceTelemetry using the sink's default logic
-                // .. but without the log level, and (rendered) message (template) included in the Properties
-                foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
-                {
-                    // then go ahead and post-process the telemetry's context to contain the user id as desired
-                    if (logEvent.Properties.ContainsKey("UserId"))
-                    {
-                        telemetry.Context.User.Id = logEvent.Properties["UserId"].ToString();
-                    }
-                    // post-process the telemetry's context to contain the operation id
-                    if (logEvent.Properties.ContainsKey("operation_Id"))
-                    {
-                        telemetry.Context.Operation.Id = logEvent.Properties["operation_Id"].ToString();
-                    }
-                    // post-process the telemetry's context to contain the operation parent id
-                    if (logEvent.Properties.ContainsKey("operation_parentId"))
-                    {
-                        telemetry.Context.Operation.ParentId = logEvent.Properties["operation_parentId"].ToString();
-                    }
-                    // typecast to ISupportProperties so you can manipulate the properties as desired
-                    ISupportProperties propTelematry = (ISupportProperties)telemetry;
+                // then go ahead and post-process the telemetry's context to contain the user id as desired
+                if (logEvent.Properties.ContainsKey("UserId"))
+                    telemetry.Context.User.Id = logEvent.Properties["UserId"].ToString();
+                // post-process the telemetry's context to contain the operation id
+                if (logEvent.Properties.ContainsKey("operation_Id"))
+                    telemetry.Context.Operation.Id = logEvent.Properties["operation_Id"].ToString();
+                // post-process the telemetry's context to contain the operation parent id
+                if (logEvent.Properties.ContainsKey("operation_parentId"))
+                    telemetry.Context.Operation.ParentId = logEvent.Properties["operation_parentId"].ToString();
+                // typecast to ISupportProperties so you can manipulate the properties as desired
+                var propTelematry = (ISupportProperties)telemetry;
 
-                    // find redundent properties
-                    var removeProps = new[] { "UserId", "operation_parentId", "operation_Id" };
-                    removeProps = removeProps.Where(prop => propTelematry.Properties.ContainsKey(prop)).ToArray();
+                // find redundent properties
+                var removeProps = new[] { "UserId", "operation_parentId", "operation_Id" };
+                removeProps = removeProps.Where(prop => propTelematry.Properties.ContainsKey(prop)).ToArray();
 
-                    foreach (var prop in removeProps)
-                    {
-                        // remove redundent properties
-                        propTelematry.Properties.Remove(prop);
-                    }
+                foreach (var prop in removeProps)
+                    // remove redundent properties
+                    propTelematry.Properties.Remove(prop);
 
-                    yield return telemetry;
-                }
+                yield return telemetry;
             }
         }
     }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/CustomiseEventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/CustomiseEventTelemetryConverterTest.cs
@@ -3,24 +3,19 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class CustomiseEventTelemetryConverterTest : ApplicationInsightsTest
 {
-    public class CustomiseEventTelemetryConverterTest : ApplicationInsightsTest
+    class IncludeRenderedMessageConverter : EventTelemetryConverter
     {
-        public CustomiseEventTelemetryConverterTest() : base()
+        public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent,
+            ISupportProperties telemetryProperties, IFormatProvider formatProvider)
         {
-
-        }
-
-        private class IncludeRenderedMessageConverter : EventTelemetryConverter
-        {
-            public override void ForwardPropertiesToTelemetryProperties(LogEvent logEvent, ISupportProperties telemetryProperties, IFormatProvider formatProvider)
-            {
-                base.ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
-                    includeLogLevel: false,
-                    includeRenderedMessage: true,
-                    includeMessageTemplate: false);
-            }
+            base.ForwardPropertiesToTelemetryProperties(logEvent, telemetryProperties, formatProvider,
+                includeLogLevel: false,
+                includeRenderedMessage: true,
+                includeMessageTemplate: false);
         }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/DottedOutFormattingTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/DottedOutFormattingTest.cs
@@ -2,37 +2,35 @@
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class DottedOutFormattingTest : ApplicationInsightsTest
 {
-    public class DottedOutFormattingTest : ApplicationInsightsTest
+    public DottedOutFormattingTest() : base(new DottedOutTrace())
     {
-        public DottedOutFormattingTest() : base(new DottedOutTrace())
-        {
+    }
 
-        }
+    [Fact]
+    public void Json_parameter_is_dotted_out()
+    {
+        var position = new { Latitude = 25, Longitude = 134 };
+        var elapsedMs = 34;
+        var numbers = new[] { 1, 2, 3, 4 };
 
-        [Fact]
-        public void Json_parameter_is_dotted_out()
-        {
-            var position = new { Latitude = 25, Longitude = 134 };
-            var elapsedMs = 34;
-            var numbers = new int[] { 1, 2, 3, 4 };
+        Logger.Information("Processed {@Position} in {Elapsed:000} ms., str {str}, numbers: {numbers}", position,
+            elapsedMs, "test", numbers);
 
-            Logger.Information("Processed {@Position} in {Elapsed:000} ms., str {str}, numbers: {numbers}", position, elapsedMs, "test", numbers);
+        Assert.Equal("34", LastSubmittedTraceTelemetry.Properties["Elapsed"]);
+        Assert.Equal("25", LastSubmittedTraceTelemetry.Properties["Position.Latitude"]);
+        Assert.Equal("134", LastSubmittedTraceTelemetry.Properties["Position.Longitude"]);
+        Assert.Equal("1", LastSubmittedTraceTelemetry.Properties["numbers.0"]);
+        Assert.Equal("2", LastSubmittedTraceTelemetry.Properties["numbers.1"]);
+        Assert.Equal("3", LastSubmittedTraceTelemetry.Properties["numbers.2"]);
+        Assert.Equal("4", LastSubmittedTraceTelemetry.Properties["numbers.3"]);
+    }
 
-            Assert.Equal("34", LastSubmittedTraceTelemetry.Properties["Elapsed"]);
-            Assert.Equal("25", LastSubmittedTraceTelemetry.Properties["Position.Latitude"]);
-            Assert.Equal("134", LastSubmittedTraceTelemetry.Properties["Position.Longitude"]);
-            Assert.Equal("1", LastSubmittedTraceTelemetry.Properties["numbers.0"]);
-            Assert.Equal("2", LastSubmittedTraceTelemetry.Properties["numbers.1"]);
-            Assert.Equal("3", LastSubmittedTraceTelemetry.Properties["numbers.2"]);
-            Assert.Equal("4", LastSubmittedTraceTelemetry.Properties["numbers.3"]);
-        }
-
-        private class DottedOutTrace : TraceTelemetryConverter
-        {
-            public override IValueFormatter ValueFormatter => new ApplicationInsightsDottedValueFormatter();
-        }
-
+    class DottedOutTrace : TraceTelemetryConverter
+    {
+        public override IValueFormatter ValueFormatter => new ApplicationInsightsDottedValueFormatter();
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -1,33 +1,32 @@
 ﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class EventTelemetryConverterTest : ApplicationInsightsTest
 {
-    public class EventTelemetryConverterTest : ApplicationInsightsTest
+    public EventTelemetryConverterTest() : base(new EventTelemetryConverter())
     {
-        public EventTelemetryConverterTest() : base(new EventTelemetryConverter())
-        {
-        }
+    }
 
-        [Fact]
-        public void MessagesAreFormattedWithoutQuotedStrings()
-        {
-            Logger.Information("Hello, {Name}!", "world");
-            Assert.Equal("Hello, world!", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
-        }
+    [Fact]
+    public void MessagesAreFormattedWithoutQuotedStrings()
+    {
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Equal("Hello, world!", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+    }
 
-        [Fact]
-        public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
-        {
-            Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-            Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
-        }
+    [Fact]
+    public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
+    {
+        Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
+        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+    }
 
-        [Fact]
-        public void MessageQuotesAreNotEscaped()
-        {
-            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
-        }
+    [Fact]
+    public void MessageQuotesAreNotEscaped()
+    {
+        Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+        Assert.Equal("Data: This string is \"quoted\"", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -1,72 +1,72 @@
-using Microsoft.ApplicationInsights.Channel;
 using Serilog.Context;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class FormattingTests : ApplicationInsightsTest
 {
-    public class FormattingTests : ApplicationInsightsTest
+    [Fact]
+    public void Log_level_is_not_in_trace_custom_property()
     {
-        [Fact]
-        public void Log_level_is_not_in_trace_custom_property()
-        {
-            Logger.Information("test");
+        Logger.Information("test");
 
-            Assert.False(LastSubmittedTraceTelemetry.Properties.ContainsKey("LogLevel"));
+        Assert.False(LastSubmittedTraceTelemetry.Properties.ContainsKey("LogLevel"));
+    }
+
+    [Fact]
+    public void Message_template_is_in_trace_custom_property()
+    {
+        Logger.Information("test");
+
+        Assert.True(LastSubmittedTraceTelemetry.Properties.ContainsKey("MessageTemplate"));
+    }
+
+    [Fact]
+    public void Message_properties_include_log_context()
+    {
+        using (LogContext.PushProperty("custom1", "value1"))
+        {
+            Logger.Information("test context");
+
+            Assert.True(LastSubmittedTraceTelemetry.Properties.TryGetValue("custom1", out var value1) &&
+                        value1 == "value1");
         }
+    }
 
-        [Fact]
-        public void Message_template_is_in_trace_custom_property()
+    [Fact]
+    public void Json_parameter_is_compact()
+    {
+        var position = new { Latitude = 25, Longitude = 134 };
+        var elapsedMs = 34;
+        var numbers = new[] { 1, 2, 3, 4 };
+
+        Logger.Information("Processed {@Position} in {Elapsed:000} ms., str {str}, numbers: {numbers}", position,
+            elapsedMs, "test", numbers);
+
+        Assert.Equal("34", LastSubmittedTraceTelemetry.Properties["Elapsed"]);
+        Assert.Equal("{\"Latitude\":25,\"Longitude\":134}", LastSubmittedTraceTelemetry.Properties["Position"]);
+        Assert.Equal("[1,2,3,4]", LastSubmittedTraceTelemetry.Properties["numbers"]);
+    }
+
+    [Fact]
+    public void OperationId_from_logContext_is_included()
+    {
+        using (LogContext.PushProperty("operationId", "myId1"))
         {
-            Logger.Information("test");
+            Logger.Information("capture id?");
 
-            Assert.True(LastSubmittedTraceTelemetry.Properties.ContainsKey("MessageTemplate"));
+            Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Operation.Id);
         }
+    }
 
-        [Fact]
-        public void Message_properies_include_log_context()
+    [Fact]
+    public void Version_from_logContext_is_included()
+    {
+        using (LogContext.PushProperty("version", "myId1"))
         {
-            using (LogContext.PushProperty("custom1", "value1"))
-            {
-                Logger.Information("test context");
+            Logger.Information("capture id?");
 
-                Assert.True(LastSubmittedTraceTelemetry.Properties.TryGetValue("custom1", out string value1) && value1 == "value1");
-            }
-        }
-
-        [Fact]
-        public void Json_parameter_is_compact()
-        {
-            var position = new { Latitude = 25, Longitude = 134 };
-            var elapsedMs = 34;
-            var numbers = new int[] { 1, 2, 3, 4 };
-
-            Logger.Information("Processed {@Position} in {Elapsed:000} ms., str {str}, numbers: {numbers}", position, elapsedMs, "test", numbers);
-
-            Assert.Equal("34", LastSubmittedTraceTelemetry.Properties["Elapsed"]);
-            Assert.Equal("{\"Latitude\":25,\"Longitude\":134}", LastSubmittedTraceTelemetry.Properties["Position"]);
-            Assert.Equal("[1,2,3,4]", LastSubmittedTraceTelemetry.Properties["numbers"]);
-        }
-
-        [Fact]
-        public void OperationId_from_logContext_is_included()
-        {
-            using (LogContext.PushProperty("operationId", "myId1"))
-            {
-                Logger.Information("capture id?");
-
-                Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Operation.Id);
-            }
-        }
-
-        [Fact]
-        public void Version_from_logContext_is_included()
-        {
-            using (LogContext.PushProperty("version", "myId1"))
-            {
-                Logger.Information("capture id?");
-
-                Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Component.Version);
-            }
+            Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Component.Version);
         }
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/Serilog.Sinks.ApplicationInsights.Tests.csproj
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/Serilog.Sinks.ApplicationInsights.Tests.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net4.8</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -15,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Serilog.Sinks.ApplicationInsights\Serilog.Sinks.ApplicationInsights.csproj" />
+    <ProjectReference Include="..\..\src\Serilog.Sinks.ApplicationInsights\Serilog.Sinks.ApplicationInsights.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TelemetryConversionTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TelemetryConversionTest.cs
@@ -1,52 +1,50 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Serilog.Events;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class TelemetryConversionTest : ApplicationInsightsTest
 {
-    public class TelemetryConversionTest : ApplicationInsightsTest
+    public TelemetryConversionTest() : base(new CustomConverter())
     {
-        public TelemetryConversionTest() : base(new CustomConverter())
+    }
+
+    [Fact]
+    public void Converter_triggers()
+    {
+        Logger.Information("test");
+
+        Assert.Single(SubmittedTelemetry);
+    }
+
+    [Fact]
+    public void Convert_to_two_traces()
+    {
+        Logger.Information("two");
+
+        Assert.Equal(expected: 2, SubmittedTelemetry.Count(t => t is TraceTelemetry tt && tt.Message == "two"));
+    }
+
+    class CustomConverter : TraceTelemetryConverter
+    {
+        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
+            var tt = base.Convert(logEvent, formatProvider);
 
-        }
-
-        [Fact]
-        public void Converter_triggers()
-        {
-            Logger.Information("test");
-
-            Assert.Single(SubmittedTelemetry);
-        }
-
-        [Fact]
-        public void Convert_to_two_traces()
-        {
-            Logger.Information("two");
-
-            Assert.Equal(2, SubmittedTelemetry.Count(t => t is TraceTelemetry tt && tt.Message == "two"));
-        }
-
-        private class CustomConverter : TraceTelemetryConverter
-        {
-            public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+            if (logEvent.MessageTemplate.Text == "two")
             {
-                IEnumerable<ITelemetry> tt = base.Convert(logEvent, formatProvider);
-
-                if (logEvent.MessageTemplate.Text == "two")
-                {
-                    yield return tt.First();
-                    yield return tt.First();
-                }
-                else
-                {
-                    yield return tt.First();
-                }
+                yield return tt.First();
+                yield return tt.First();
+            }
+            else
+            {
+                yield return tt.First();
             }
         }
     }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -1,33 +1,32 @@
 ﻿using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+public class TraceTelemetryConverterTest : ApplicationInsightsTest
 {
-    public class TraceTelemetryConverterTest : ApplicationInsightsTest
+    public TraceTelemetryConverterTest() : base(new TraceTelemetryConverter())
     {
-        public TraceTelemetryConverterTest() : base(new TraceTelemetryConverter())
-        {
-        }
+    }
 
-        [Fact]
-        public void MessagesAreFormattedWithoutQuotedStrings()
-        {
-            Logger.Information("Hello, {Name}!", "world");
-            Assert.Equal("Hello, world!", LastSubmittedTraceTelemetry.Message);
-        }
+    [Fact]
+    public void MessagesAreFormattedWithoutQuotedStrings()
+    {
+        Logger.Information("Hello, {Name}!", "world");
+        Assert.Equal("Hello, world!", LastSubmittedTraceTelemetry.Message);
+    }
 
-        [Fact]
-        public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
-        {
-            Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-            Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedTraceTelemetry.Message);
-        }
+    [Fact]
+    public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
+    {
+        Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
+        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedTraceTelemetry.Message);
+    }
 
-        [Fact]
-        public void MessageQuotesAreNotEscaped()
-        {
-            Logger.Information("Data: {MyData}", "This string is \"quoted\"");
-            Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
-        }
+    [Fact]
+    public void MessageQuotesAreNotEscaped()
+    {
+        Logger.Information("Data: {MyData}", "This string is \"quoted\"");
+        Assert.Equal("Data: This string is \"quoted\"", LastSubmittedTraceTelemetry.Message);
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/UnitTestTelemetryChannel.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/UnitTestTelemetryChannel.cs
@@ -1,39 +1,34 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Channel;
 
-namespace Serilog.Sinks.ApplicationInsights.Tests
+namespace Serilog.Sinks.ApplicationInsights.Tests;
+
+class UnitTestTelemetryChannel : ITelemetryChannel
 {
-    class UnitTestTelemetryChannel : ITelemetryChannel
+    public List<ITelemetry> SubmittedTelemetry { get; } = new();
+
+    public bool? DeveloperMode
     {
-        public List<ITelemetry> SubmittedTelemetry { get; } = new List<ITelemetry>();
+        get => false;
+        set { }
+    }
 
-        public bool? DeveloperMode
-        {
-            get => false;
-            set { }
-        }
+    public string EndpointAddress
+    {
+        get => null;
+        set { }
+    }
 
-        public string EndpointAddress
-        {
-            get => null;
-            set { }
-        }
+    public void Dispose()
+    {
+    }
 
-        public void Dispose()
-        {
+    public void Flush()
+    {
+    }
 
-        }
-
-        public void Flush()
-        {
-
-        }
-
-        public void Send(ITelemetry item)
-        {
-            SubmittedTelemetry.Add(item);
-        }
+    public void Send(ITelemetry item)
+    {
+        SubmittedTelemetry.Add(item);
     }
 }


### PR DESCRIPTION
In order to minimize irrelevant churn in future PRs, this changeset globally applies Riders default code formatting and switches the language version to C# 10.

Warnings-as-errors is also now enabled; I've added `#pragma`s to the locations where documentation or other non-trivial work is required to remove existing warnings.