### PR TITLE
Don't JSON-encode the contents of literal string properties

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsDottedValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsDottedValueFormatter.cs
@@ -59,10 +59,9 @@ public class ApplicationInsightsDottedValueFormatter : IValueFormatter
         AppendProperty(properties, key + ".Count", index.ToString());
     }
 
-    public static void WriteValue(string key, object value, IDictionary<string, string> properties)
+    static void WriteValue(string key, object value, IDictionary<string, string> properties)
     {
-        Action<string, object, IDictionary<string, string>> writer;
-        if (value == null || !LiteralWriters.TryGetValue(value.GetType(), out writer))
+        if (value == null || !LiteralWriters.TryGetValue(value.GetType(), out var writer))
         {
             AppendProperty(properties, key, value?.ToString());
             return;

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsJsonValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/ApplicationInsightsJsonValueFormatter.cs
@@ -1,10 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 
 namespace Serilog.Sinks.ApplicationInsights.Formatters;
+
+#nullable enable
 
 /// <summary>
 /// Formats properties containing structured data as JSON.
@@ -20,16 +24,25 @@ public class ApplicationInsightsJsonValueFormatter : IValueFormatter
         IDictionary<string, string> properties)
     {
         string formattedValue;
-
-        if (propertyValue is ScalarValue { Value: string literal })
+        if (propertyValue is ScalarValue sv)
         {
-            formattedValue = literal;
+            formattedValue = sv.Value switch
+            {
+                // In logs, being able to distinguish null from an empty string is often important.
+                null => "null",
+                // ISO-8601 is most accurate to parse.
+                DateTime or DateTimeOffset => ((IFormattable)sv.Value).ToString("o", CultureInfo.InvariantCulture),
+                char c => c.ToString(),
+                // Serilog's JSON representation of these values is unquoted and generally more suitable for
+                // parsing/processing than their default culture-dependent `ToString()` representations.
+                int or uint or long or ulong or decimal or byte or sbyte or short or ushort or double or 
+                    float or bool => FormatAsJson(sv),
+                _ => sv.Value.ToString() ?? "(null)"
+            };
         }
         else
         {
-            using var sw = new StringWriter();
-            _formatter.Format(propertyValue, sw);
-            formattedValue = sw.ToString();
+            formattedValue = FormatAsJson(propertyValue);
         }
 
         if (properties.ContainsKey(propertyName))
@@ -40,5 +53,12 @@ public class ApplicationInsightsJsonValueFormatter : IValueFormatter
         }
 
         properties.Add(propertyName, formattedValue);
+    }
+
+    string FormatAsJson(LogEventPropertyValue propertyValue)
+    {
+        using var sw = new StringWriter();
+        _formatter.Format(propertyValue, sw);
+        return sw.ToString();
     }
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/IValueFormatter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/Formatters/IValueFormatter.cs
@@ -3,9 +3,17 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.ApplicationInsights.Formatters;
 
-#pragma warning disable CS1591
-
+/// <summary>
+/// Convert Serilog log event properties into flat <code>(string, string)</code> pairs to send to Application Insights.
+/// </summary>
 public interface IValueFormatter
 {
+    /// <summary>
+    /// Convert the log event property <paramref name="propertyName"/> with value <paramref name="propertyValue"/>
+    /// into one or more key-value properties to send to Application Insights, adding these to <paramref name="properties"/>.
+    /// </summary>
+    /// <param name="propertyName">The Serilog log event's name for the property.</param>
+    /// <param name="propertyValue">The log event's property value.</param>
+    /// <param name="properties">The collection of string properties being built to send to Application Insights.</param>
     void Format(string propertyName, LogEventPropertyValue propertyValue, IDictionary<string, string> properties);
 }

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -43,7 +43,7 @@ public abstract class TelemetryConverterBase : ITelemetryConverter
     /// </summary>
     public const string VersionProperty = "version";
 
-    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:l}");
+    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:lj}");
 
     /// <summary>
     ///     Creates an instance of <see cref="TelemetryConverterBase" /> using default value formatter (

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -12,7 +12,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
 public class TraceTelemetryConverter : TelemetryConverterBase
 {
-    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:l}");
+    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:lj}");
 
     public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
     {

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class EventTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+        Assert.Equal("Hello, {\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
     }
 
     [Fact]

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.InteropServices;
 using Serilog.Context;
 using Xunit;
 
@@ -70,11 +72,17 @@ public class FormattingTests : ApplicationInsightsTest
         }
     }
 
-    [Fact]
-    public void Literal_string_properties_are_not_encoded()
+    [Theory]
+    [InlineData("\"some \\ \"literal string \"", "\"some \\ \"literal string \"")]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    [InlineData(null, "null")]
+    [InlineData(123.45, "123.45")]
+    [InlineData(6789, "6789")]
+    [InlineData('a', "a")]
+    public void Scalar_values_are_encoded_as_expected(object scalar, string expected)
     {
-        const string literal = "\"some \\ \"literal string \"";
-        Logger.Information("Literal is {Literal}", literal);
-        Assert.Equal(literal, LastSubmittedTraceTelemetry.Properties["Literal"]);
+        Logger.Information("Value is {Scalar}", scalar);
+        Assert.Equal(expected, LastSubmittedTraceTelemetry.Properties["Scalar"]);
     }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/FormattingTests.cs
@@ -69,4 +69,12 @@ public class FormattingTests : ApplicationInsightsTest
             Assert.Equal("myId1", LastSubmittedTraceTelemetry.Context.Component.Version);
         }
     }
+
+    [Fact]
+    public void Literal_string_properties_are_not_encoded()
+    {
+        const string literal = "\"some \\ \"literal string \"";
+        Logger.Information("Literal is {Literal}", literal);
+        Assert.Equal(literal, LastSubmittedTraceTelemetry.Properties["Literal"]);
+    }
 }

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class TraceTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedTraceTelemetry.Message);
+        Assert.Equal("Hello, {\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedTraceTelemetry.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #117

When the default `ApplicationInsightsJsonValueFormatter` is used:

 * Captured structured data including objects, arrays, and dictionaries will be recorded in accurate JSON representation
 * Strings will be preserved exactly as logged
 * `DateTime` and `DateTimeOffset` will be written as ISO-8601
 * Simple values will use a sensible default representation
 * Other data will be recorded using its `ToString()` representation

This PR also turns on the `j` flag for rendering of messages, so that in general, the way a property is rendered into a message will match the way it's recorded in the name/value payload.