### PR TITLE
Add whitespace to JSON in rendered messages, like Serilog.Sinks.Console

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TelemetryConverterBase.cs
@@ -43,7 +43,7 @@ public abstract class TelemetryConverterBase : ITelemetryConverter
     /// </summary>
     public const string VersionProperty = "version";
 
-    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:lj}");
+    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:l}");
 
     /// <summary>
     ///     Creates an instance of <see cref="TelemetryConverterBase" /> using default value formatter (

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/TelemetryConverters/TraceTelemetryConverter.cs
@@ -12,7 +12,7 @@ namespace Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
 public class TraceTelemetryConverter : TelemetryConverterBase
 {
-    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:lj}");
+    static readonly MessageTemplateTextFormatter MessageTemplateTextFormatter = new("{Message:l}");
 
     public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
     {

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class EventTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, {\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+        Assert.Equal("Hello, { \"Foo\": \"foo\", \"Bar\": 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
     }
 
     [Fact]

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/EventTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class EventTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, { \"Foo\": \"foo\", \"Bar\": 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
+        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedEventTelemetry.Properties["RenderedMessage"]);
     }
 
     [Fact]

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class TraceTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, {\"Foo\":\"foo\",\"Bar\":123}", LastSubmittedTraceTelemetry.Message);
+        Assert.Equal("Hello, { \"Foo\": \"foo\", \"Bar\": 123 }", LastSubmittedTraceTelemetry.Message);
     }
 
     [Fact]

--- a/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
+++ b/test/Serilog.Sinks.ApplicationInsights.Tests/TraceTelemetryConverterTest.cs
@@ -20,7 +20,7 @@ public class TraceTelemetryConverterTest : ApplicationInsightsTest
     public void MessagesAreFormattedWithoutQuotedStringsWhenDestructuring()
     {
         Logger.Information("Hello, {@Name}", new { Foo = "foo", Bar = 123 });
-        Assert.Equal("Hello, { \"Foo\": \"foo\", \"Bar\": 123 }", LastSubmittedTraceTelemetry.Message);
+        Assert.Equal("Hello, { Foo: \"foo\", Bar: 123 }", LastSubmittedTraceTelemetry.Message);
     }
 
     [Fact]


### PR DESCRIPTION
After PR #188 (I assume), destructured data are rendered (in the message) without whitespace:

```
Hello, {"Foo":"foo","Bar":123}
```

This is fine for properties, but the rendered message is intended to be human-readable, and this format is unnecessarily hard on the eyes.

I suggest using the same format as Serilog.Sinks.Console, which adds whitespace in the JSON to make it easier to read:

```
Hello, { "Foo": "foo", "Bar": 123 }
```

The first (and currently only) commit in this PR updates the tests to indicate my desired behavior. I am unsure how to proceed, because I don't know how this is done in Serilog.Sinks.Console.

Any input on how to proceed is most welcome.