### PR TITLE
Updated Azure Function section in README.md

### DIFF
--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationApplicationInsightsExtensions.cs
@@ -105,23 +105,23 @@ public static class LoggerConfigurationApplicationInsightsExtensions
     ///     have already constructed AI telemetry configuration, which is extremely rare.
     /// </summary>
     /// <param name="loggerConfiguration">The logger configuration.</param>
-    /// <param name="instrumentationKey">Required Application Insights key.</param>
+    /// <param name="connectionString">Required Application Insights connection string.</param>
     /// <param name="telemetryConverter">Required telemetry converter.</param>
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
     /// <param name="levelSwitch">Logging level switch for this sink</param>
     /// <returns></returns>
     public static LoggerConfiguration ApplicationInsights(
         this LoggerSinkConfiguration loggerConfiguration,
-        string instrumentationKey,
+        string connectionString,
         ITelemetryConverter telemetryConverter,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch levelSwitch = null)
     {
 #pragma warning disable CS0618
-        var client = new TelemetryClient();
-#pragma warning restore CS0618
-
-        if (!string.IsNullOrWhiteSpace(instrumentationKey)) client.InstrumentationKey = instrumentationKey;
+        var config = TelemetryConfiguration.CreateDefault();
+        if (!string.IsNullOrWhiteSpace(connectionString)) config.ConnectionString = connectionString;
+        var client = new TelemetryClient(config);
+#pragma warning restore CS0618        
 
         return loggerConfiguration.Sink(new ApplicationInsightsSink(client, telemetryConverter),
             restrictedToMinimumLevel, levelSwitch);


### PR DESCRIPTION
This is the recommended approach by Microsoft
https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection#registering-services

Logging services
If you need your own logging provider, register a custom type as an instance of [ILoggerProvider](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.iloggerfactory), which is available through the [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/) NuGet package.

Application Insights is added by Azure Functions automatically.